### PR TITLE
Correcting documentation where Type is coming with Wrong Response Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,21 +48,21 @@ namespace RESTFulSampleServer.HyperMedia
                 Action = HttpActionVerb.GET,
                 Href = urlHelper.Link("DefaultApi", url),
                 Rel = RelationType.self,
-                Type = RensponseTypeFormat.DefaultGet
+                Type = ResponseTypeFormat.DefaultGet
             });
             content.Links.Add(new HyperMediaLink()
             {
                 Action = HttpActionVerb.POST,
                 Href = urlHelper.Link("DefaultApi", url),
                 Rel = RelationType.self,
-                Type = RensponseTypeFormat.DefaultPost
+                Type = ResponseTypeFormat.DefaultPost
             });
             content.Links.Add(new HyperMediaLink()
             {
                 Action = HttpActionVerb.PUT,
                 Href = urlHelper.Link("DefaultApi", url),
                 Rel = RelationType.self,
-                Type = RensponseTypeFormat.DefaultPost
+                Type = ResponseTypeFormat.DefaultPost
             });
             content.Links.Add(new HyperMediaLink()
             {


### PR DESCRIPTION
The Type instance lines have a character error in the ResponseTypeFormat method call. Before the character 's', there was an 'n' character.